### PR TITLE
Update org.gnome.Platform to 41

### DIFF
--- a/org.gustavoperedo.FontDownloader.json
+++ b/org.gustavoperedo.FontDownloader.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gustavoperedo.FontDownloader",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "41",
     "sdk" : "org.gnome.Sdk",
     "command" : "fontdownloader",
     "finish-args" : [

--- a/org.gustavoperedo.FontDownloader.json
+++ b/org.gustavoperedo.FontDownloader.json
@@ -27,26 +27,6 @@
     ],
     "modules" : [
         {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dprofiling=false",
-                "-Dintrospection=enabled",
-                "-Dgtk_doc=false",
-                "-Dtests=false",
-                "-Dexamples=false",
-                "-Dvapi=false",
-                "-Dglade_catalog=disabled"
-            ],
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/libhandy/1.0/libhandy-1.0.0.tar.xz",
-                    "sha256" : "a9398582f47b7d729205d6eac0c068fef35aaf249fdd57eea3724f8518d26699"
-                }
-            ]
-        },
-        {
             "name" : "fontdownloader",
             "builddir" : true,
             "buildsystem" : "meson",


### PR DESCRIPTION
Update to latest and greatest GNOME v41 runtime. Also drop `libhandy` since now it's part of new GNOME runtime. Tested this build locally and LGTM so far.