### PR TITLE
Update Runtime and switch to Gitlab Repo

### DIFF
--- a/org.gustavoperedo.FontDownloader.json
+++ b/org.gustavoperedo.FontDownloader.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gustavoperedo.FontDownloader",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "fontdownloader",
     "finish-args" : [
@@ -33,8 +33,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://github.com/GustavoPeredo/Font-Downloader.git",
-                    "commit" : "a7120ab3af860a3376f765c3aad8ddd783f393e5"
+                    "url" : "https://gitlab.gnome.org/GustavoPeredo/font-downloader",
+                    "commit" : "7ce62ddda4885dff5402c80b389bfcb4be909d7e"
                 }
             ]
         }

--- a/org.gustavoperedo.FontDownloader.json
+++ b/org.gustavoperedo.FontDownloader.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gustavoperedo.FontDownloader",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime" : "org.freedesktop.Platform",
+    "runtime-version" : "22.08",
     "sdk" : "org.gnome.Sdk",
     "command" : "fontdownloader",
     "finish-args" : [
@@ -34,7 +34,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GustavoPeredo/font-downloader",
-                    "commit" : "7ce62ddda4885dff5402c80b389bfcb4be909d7e"
+                    "commit" : "40bda6486605561f3041940c9352fd3a6ff300ae"
                 }
             ]
         }


### PR DESCRIPTION
Font Downloader have make a complete migration for gitlab, for default the github repo is not more updated