### PR TITLE
bump gnome runtime to v46 and app to v10

### DIFF
--- a/org.gustavoperedo.FontDownloader.json
+++ b/org.gustavoperedo.FontDownloader.json
@@ -34,7 +34,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/GustavoPeredo/Font-Downloader.git",
-                    "commit" : "d6e68b48f4581ecbf7fe7ca444b8ec0f13adb6ed"
+                    "commit" : "07e0fbe8b1d879a979e96796df37af0216484c3c"
                 }
             ]
         }

--- a/org.gustavoperedo.FontDownloader.json
+++ b/org.gustavoperedo.FontDownloader.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gustavoperedo.FontDownloader",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "fontdownloader",
     "finish-args" : [

--- a/org.gustavoperedo.FontDownloader.json
+++ b/org.gustavoperedo.FontDownloader.json
@@ -11,7 +11,6 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--filesystem=~/.local/share/fonts:create",
-        "--filesystem=/usr/share/fonts",
         "--filesystem=xdg-download"
     ],
     "cleanup" : [


### PR DESCRIPTION
The GNOME 44 runtime is no longer supported as of March 20, 2024.
Closes https://github.com/flathub/org.gustavoperedo.FontDownloader/issues/9

Bumps app to v10
Closes https://github.com/GustavoPeredo/Font-Downloader/issues/112