### PR TITLE
chore: bump runtime to gnome 49

### DIFF
--- a/org.gustavoperedo.FontDownloader.json
+++ b/org.gustavoperedo.FontDownloader.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gustavoperedo.FontDownloader",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "command" : "fontdownloader",
     "finish-args" : [


### PR DESCRIPTION
still works